### PR TITLE
update analyzer to ^7.3.0 and version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,10 @@ Modified to support the latest version.
 * flutter_lints: ^5.0.0
 * analyzer: ^6.7.0
 _Android Gradle 8.1.0 or 8.3.0_
+
+## 2.1.0
+Modified to support the latest version.
+* Flutter >= 3.27.0
+* Dart >= 3.5.0
+* flutter_lints: ^5.0.0
+* analyzer: ^7.3.0

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Note the available version of the flutter for reasons of dependence within the `
 |:-------------------:|:-------------------:|:------------------|
 | 1.0.2 | >= 3.19.0 | flutter_lints: ^4.0.0<br>analyzer: ^6.4.1 |
 | 2.0.0 | >= 3.24.0 | flutter_lints: ^5.0.0<br>analyzer: ^6.7.0 |
+| 2.1.0 | >= 3.27.0 | flutter_lints: ^5.0.0<br>analyzer: ^7.3.0 |
 
 
 ## Getting Started

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aqlinter
 description: "This is AQoong's favorit linter set"
-version: 2.0.0
+version: 2.1.0
 homepage: "https://aqoong.site"
 repository: "https://github.com/aqoong/flutter-aqlinter"
 topics:
@@ -14,6 +14,6 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_lints: ^5.0.0
-  analyzer: ^6.7.0
+  analyzer: ^7.3.0
 
 license: MIT


### PR DESCRIPTION
This commit updates the `analyzer` dependency to version `^7.3.0` in `pubspec.yaml`, and the library version to `2.1.0`. Also updated `README.md` and `CHANGELOG.md`.